### PR TITLE
isValidateDisabled - fix error when no parents

### DIFF
--- a/src/services/validation.service.js
+++ b/src/services/validation.service.js
@@ -157,7 +157,7 @@ angular.module('bootstrap.angular.validation').factory('BsValidationService', ['
       }
 
       var $parentForm = $element.parents('form');
-      return $parentForm && $parentForm[0].attributes.hasOwnProperty(attribute);
+      return $parentForm[0] && $parentForm[0].attributes.hasOwnProperty(attribute);
     },
 
     removeErrorClass: function($formGroupElement) {


### PR DESCRIPTION
Elements that haven't been inserted into the DOM yet (like in angular-ui-select) would cause errors to be printed to the Javascript console. Due to a bug in isValidationDisabled.

This fixes that bug and prevents the errors.
