### PR TITLE
Prevent module from disabling non-angular forms

### DIFF
--- a/src/directives/form.directive.js
+++ b/src/directives/form.directive.js
@@ -39,8 +39,6 @@ angular.module('bootstrap.angular.validation').directive('form', [
             };
 
             formElement.on('submit', function(e) {
-              e.preventDefault();
-
               // If any of the form element has not passed the validation
               if (formController.$invalid) {
                 // Then focus the first invalid element
@@ -70,8 +68,8 @@ angular.module('bootstrap.angular.validation').directive('form', [
                *
                * https://api.jquery.com/event.stopimmediatepropagation/
                */
-              e.stopImmediatePropagation();
-              return false;
+              //e.stopImmediatePropagation();
+              return true;
             });
           };
 


### PR DESCRIPTION
Once this module is included in an application, it will cause all forms to silently to fail to submit.

Normal forms that were not designed for angular would silently fail to submit because of the e.preventDefault()

Angular forms that used ng-submit to perform the action were also not getting called (I think because of the preventImmediatePropogation)

This patch is a bit rough and ready, but I've tested it agains:
- A normal non-angular form
- An angular form using bootstrap validation provided by this module

And both work as expected.

Changes:
form.on('submit') return true unless it's invalid
form.on('submit') do not call preventDefault or preventPropogation
