### PR TITLE
the success class was never removed

### DIFF
--- a/src/services/validation.service.js
+++ b/src/services/validation.service.js
@@ -75,7 +75,7 @@ angular.module('bootstrap.angular.validation').factory('BsValidationService', ['
     },
 
     addErrorClass: function($formGroupElement) {
-      this.removeErrorClass($formGroupElement);
+      this.removeSuccessClass($formGroupElement);
       $formGroupElement.addClass(validationConfig.errorClass);
     },
 


### PR DESCRIPTION
the success class was never removed so the validation message appeared in wrong style for errors that appeared after a successful validation.
