### PR TITLE
Add hidden class to tooltip to keep from blocking

### DIFF
--- a/src/services/tooltip.message.service.js
+++ b/src/services/tooltip.message.service.js
@@ -63,7 +63,9 @@ angular.module('bootstrap.angular.validation').factory('tooltipMessageService', 
 
       hideErrorMessage: function ($element, $formGroupElement) {
         validationService.removeErrorClass($formGroupElement);
-        getErrorTooltip($element).removeClass('in');
+        var tip = getErrorTooltip($element);
+        tip.removeClass('in');
+        tip.addClass('hidden');
       },
 
       showErrorMessage: function ($element, $attr, ngModelController) {
@@ -73,6 +75,7 @@ angular.module('bootstrap.angular.validation').factory('tooltipMessageService', 
         var appendToBody = validationConfig.tooltipAppendToBody;
 
         $errorTooltip.find('.tooltip-inner').html(message);
+        $errorTooltip.removeClass('hidden');
 
         var $position = $injector.get('$uibPosition');
         var ttPosition = $position.positionElements($element, $errorTooltip, placement, appendToBody);


### PR DESCRIPTION
The tooltips are set to opacity 0 but can still block html interaction, so adding the bootstrap .hidden class solves this